### PR TITLE
Fix index error #15

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -200,9 +200,9 @@ class Generators():
         """You have a 40% chance to get a potion at the end of combat.
         -10% when you get a potion.
         +10% when you don't get a potion."""
-        common_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Common" and (potion.get("Class") == "All" or entity.player_class in potion.get('Class'))]
-        uncommon_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Uncommon" and (potion.get("Class") == "All" or entity.player_class in potion.get('Class'))]
-        rare_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Rare" and (potion.get("Class") == "All" or entity.player_class in potion.get('Class'))]
+        common_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Common" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
+        uncommon_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Uncommon" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
+        rare_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Rare" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
         all_potions = common_potions + uncommon_potions + rare_potions
         rarities = [common_potions, uncommon_potions, rare_potions]
         for pool in rarities:

--- a/helper.py
+++ b/helper.py
@@ -178,12 +178,12 @@ class Generators():
         common_cards = [card for card in card_pool.values() if card.get("Rarity") == "Common" and card.get("Type") not in ('Status', 'Curse') and card.get('Class') == entity.player_class]
         uncommon_cards = [card for card in card_pool.values() if card.get("Rarity") == "Uncommon" and card.get("Type") not in ('Status', 'Curse') and card.get('Class') == entity.player_class]
         rare_cards = [card for card in card_pool.values() if card.get("Rarity") == "Rare" and card.get("Type") not in ('Status', 'Curse') and card.get('Class') == entity.player_class]
-        rarities =  [common_cards, uncommon_cards, rare_cards]
-        for pool in rarities:
-            identifier = {"Common": common_cards, "Uncommon": uncommon_cards,  "Rare": rare_cards}
-            assert len(pool) > 0, f"{identifier[pool]} pool is empty."
-        rewards = []
+        assert len(common_cards) > 0, f"Common pool is empty."
+        assert len(uncommon_cards) > 0, f"Uncommon pool is empty."
+        assert len(rare_cards) > 0, f"Rare pool is empty."
 
+        rarities =  [common_cards, uncommon_cards, rare_cards]
+        rewards = []
         if reward_tier == 'Normal':
             chances = [0.60, 0.37, 0.03]
         elif reward_tier == 'Elite':
@@ -203,11 +203,12 @@ class Generators():
         common_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Common" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
         uncommon_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Uncommon" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
         rare_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Rare" and (potion.get("Class") == "Any" or entity.player_class in potion.get('Class'))]
+        assert len(common_potions) > 0, f"Common potions pool is empty."
+        assert len(uncommon_potions) > 0, f"Uncommon potions pool is empty."
+        assert len(rare_potions) > 0, f"Rare potions pool is empty."
+
         all_potions = common_potions + uncommon_potions + rare_potions
         rarities = [common_potions, uncommon_potions, rare_potions]
-        for pool in rarities:
-            idenifier = {"Common": common_potions, "Uncommon": uncommon_potions, "Rare": rare_potions}
-            assert len(pool) > 0, f"{idenifier[pool]} pool is empty."
         rewards = []
         for _ in range(amount):
             if chance_based:

--- a/helper.py
+++ b/helper.py
@@ -206,7 +206,7 @@ class Generators():
         all_potions = common_potions + uncommon_potions + rare_potions
         rarities = [common_potions, uncommon_potions, rare_potions]
         for pool in rarities:
-            idenifier = {common_potions: "Common", uncommon_potions: "Uncommon", rare_potions: "Rare"}
+            idenifier = {"Common": common_potions, "Uncommon": uncommon_potions, "Rare": rare_potions}
             assert len(pool) > 0, f"{idenifier[pool]} pool is empty."
         rewards = []
         for _ in range(amount):

--- a/helper.py
+++ b/helper.py
@@ -180,7 +180,7 @@ class Generators():
         rare_cards = [card for card in card_pool.values() if card.get("Rarity") == "Rare" and card.get("Type") not in ('Status', 'Curse') and card.get('Class') == entity.player_class]
         rarities =  [common_cards, uncommon_cards, rare_cards]
         for pool in rarities:
-            identifier = {common_cards: "Common", uncommon_cards: "Uncommon", rare_cards: "Rare"}
+            identifier = {"Common": common_cards, "Uncommon": uncommon_cards,  "Rare": rare_cards}
             assert len(pool) > 0, f"{identifier[pool]} pool is empty."
         rewards = []
 


### PR DESCRIPTION
Actually fixes #15 

The broken lines looked like this:
```python
common_potions: list[dict] = [potion for potion in potion_pool.values() if potion.get("Rarity") == "Common" and (potion.get("Class") == "All" or entity.player_class in potion.get('Class'))]
```

Note the `== "All"`

The filter was looking for "All" instead of the correct "Any". Because it had the wrong word, the list was empty, so when it tried to take the `[0]` element of an empty list, it crashed. (It should be noted that the bug will still be there if the `potion_pool` doesn't include at least 1 of each rarity of potion.)

You mentioned you're new at Python, so I'll use this as a teaching moment. There are a few things that could be improved here to avoid these errors in the future:

- **Indepedent functions.** The 3 lines with errors are essentially filters on the larger pool of potions. These filters could be their own small testable functions
- **Enumerations.** The error was a typo. If an Enum was used instead, such a typo would get caught during linting -- there would be a squiggly line under `Rarity.All` indicating a problem.
- **Potion classes.** Instead of a dict of dicts, if potions were a class, these attributes could again be checked by the linter.