### PR TITLE
Test to view all cards in all conditions

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -41,10 +41,13 @@ class Displayer():
             pile = random.sample(pile, len(pile))
         counter = 1
         for card in pile:
+            if card.get('Energy', float('inf')) == 'player.energy':
+                playable_special_case = entity.energy
+            else:
+                playable_special_case = card.get('Energy', float('inf'))
             keywords = {'Upgraded': card.get('Upgraded', False), 'Upgradable': not card.get('Upgraded') and (card['Name'] == 'Burn 'or card['Type'] not in ('Curse', 'Status')),
                           'Removable': card.get('Removable', True), 'Skill': card['Type'] == 'Skill', 'Attack': card['Type'] == 'Attack', 'Power': card['Type'] == 'Power',
-                          'Playable': card.get('Energy', float('inf')) <= entity.energy}
-            assert condition in keywords, f"The passed condition('{condition}') is not a valid condition."
+                          'Playable': playable_special_case <= entity.energy}
             changed_energy = 'light-red' if not card.get('Changed Energy') else 'green'
             info_stripped = strip_tags(card['Info'])    # can't nest markup tags
             if keywords.get(condition, True):

--- a/helper.py
+++ b/helper.py
@@ -46,12 +46,13 @@ class Displayer():
                           'Playable': card.get('Energy', float('inf')) <= entity.energy}
             assert condition in keywords, f"The passed condition('{condition}') is not a valid condition."
             changed_energy = 'light-red' if not card.get('Changed Energy') else 'green'
+            info_stripped = strip_tags(card['Info'])    # can't nest markup tags
             if keywords.get(condition, True):
-                ansiprint(f"{counter}: <{card['Rarity'].lower()}>{card['Name']}</{card['Rarity'].lower()}> | <{card['Type'].lower()}>{card['Type']}</{card['Type'].lower()}> | <{changed_energy}>{card.get('Energy', 'Unplayable')}{' Energy' if card.get('Energy') is not None else ''}</{changed_energy}> | <yellow>{card['Info']}</yellow>".replace('Σ', '').replace('꫱', ''))
+                ansiprint(f"{counter}: <{card['Rarity'].lower()}>{card['Name']}</{card['Rarity'].lower()}> | <{card['Type'].lower()}>{card['Type']}</{card['Type'].lower()}> | <{changed_energy}>{card.get('Energy', 'Unplayable')}{' Energy' if card.get('Energy') is not None else ''}</{changed_energy}> | <yellow>{info_stripped}</yellow>".replace('Σ', '').replace('꫱', ''))
                 counter += 1
                 sleep(0.05)
             else:
-                ansiprint(f"{counter}: <light-black>{card['Name']} | {card['Type']} | {card.get('Energy', 'Unplayable')}{' Energy' if card.get('Energy') else ''} | {card['Info']}</light-black>".replace('Σ', '').replace('꫱', ''))
+                ansiprint(f"{counter}: <light-black>{card['Name']} | {card['Type']} | {card.get('Energy', 'Unplayable')}{' Energy' if card.get('Energy') else ''} | {info_stripped}</light-black>".replace('Σ', '').replace('꫱', ''))
                 counter += 1
                 sleep(0.05)
         if end:
@@ -620,3 +621,7 @@ class EffectInterface():
 ei = EffectInterface()
 gen = Generators()
 view = Displayer()
+
+def strip_tags(string: str) -> str:
+    '''Removes all tags from a string'''
+    return re.sub('<[^<]+?>', '', string)

--- a/test_view.py
+++ b/test_view.py
@@ -1,0 +1,17 @@
+import helper
+import entities
+
+def test_view_piles_on_all_cards(monkeypatch):
+  all_cards = [card for card in entities.cards.values()]
+  entity = entities.create_player()
+  entity.energy = 3
+  all_conditions = ['Upgraded' ,'Upgradable' ,'Removable' ,'Skill' ,'Attack' ,'Power' ,'Playable']
+
+  with monkeypatch.context() as m:
+    # Patch sleeps so it's faster
+    # m.setattr(helper, 'sleep', lambda x: None)
+    # m.setattr(entities, 'sleep', lambda x: None)
+
+    for condition in all_conditions:
+      helper.view.view_piles(pile=all_cards, entity=entity, end=False, condition=condition)
+

--- a/test_view.py
+++ b/test_view.py
@@ -1,16 +1,17 @@
 import helper
+import items
 import entities
 
 def test_view_piles_on_all_cards(monkeypatch):
-  all_cards = [card for card in entities.cards.values()]
+  all_cards = [card for card in items.cards.values()]
   entity = entities.create_player()
   entity.energy = 3
   all_conditions = ['Upgraded' ,'Upgradable' ,'Removable' ,'Skill' ,'Attack' ,'Power' ,'Playable']
 
   with monkeypatch.context() as m:
     # Patch sleeps so it's faster
-    # m.setattr(helper, 'sleep', lambda x: None)
-    # m.setattr(entities, 'sleep', lambda x: None)
+    m.setattr(helper, 'sleep', lambda x: None)
+    m.setattr(entities, 'sleep', lambda x: None)
 
     for condition in all_conditions:
       print(f"===== Condition: {condition} ======")

--- a/test_view.py
+++ b/test_view.py
@@ -13,5 +13,6 @@ def test_view_piles_on_all_cards(monkeypatch):
     # m.setattr(entities, 'sleep', lambda x: None)
 
     for condition in all_conditions:
+      print(f"===== Condition: {condition} ======")
       helper.view.view_piles(pile=all_cards, entity=entity, end=False, condition=condition)
 

--- a/test_view.py
+++ b/test_view.py
@@ -16,3 +16,7 @@ def test_view_piles_on_all_cards(monkeypatch):
       print(f"===== Condition: {condition} ======")
       helper.view.view_piles(pile=all_cards, entity=entity, end=False, condition=condition)
 
+    # Also test the default condition
+    print(f"===== Condition: Default ======")
+    helper.view.view_piles(pile=all_cards, entity=entity, end=False)
+


### PR DESCRIPTION
This calls `view_piles()` on all the cards in all the conditions, to see if any crash it. A few do. Specifically:

- One where the energy is defined as `'player.energy'` (a string) -- it chokes when trying to compare that to a number
- Several where `card["Info"]` has embedded tags, like `<buff>` -- tags can't be nested, so it chokes on being inside either a `<yellow>` or `<light-black>` tag

~~I suggest coding up special handling for the `player.energy` card, and having some way of stripping all the tags from card[Info].~~
Edit: Made the changes and pushed them.

The test takes 30+ seconds because of a `sleep()` that's called repeatedly. However, once it's not crashing, you can uncomment the monkeypatch stuff and it will run in milliseconds.
